### PR TITLE
Set disk.enableUUID=1 for VM templates

### DIFF
--- a/ova/ovf/centos.ovf
+++ b/ova/ovf/centos.ovf
@@ -138,6 +138,7 @@ file.
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
       <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
       <vmw:ExtraConfig ovf:required="false" vmw:key="nvram" vmw:value="ovf:/file/file2"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.EnableUUID" vmw:value="1"/>
     </VirtualHardwareSection>
     <vmw:StorageSection ovf:required="false" vmw:group="group1">
       <Info>Storage policy group reference</Info>

--- a/ova/ovf/photon.ovf
+++ b/ova/ovf/photon.ovf
@@ -136,6 +136,7 @@ file.
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
       <vmw:Config ovf:required="false" vmw:key="virtualICH7MPresent" vmw:value="false"/>
       <vmw:ExtraConfig ovf:required="false" vmw:key="nvram" vmw:value="ovf:/file/file2"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="disk.EnableUUID" vmw:value="1"/>
     </VirtualHardwareSection>
     <vmw:StorageSection ovf:required="false" vmw:group="group1">
       <Info>Storage policy group reference</Info>


### PR DESCRIPTION
This was a bit of a guess on how to set this properly, but per https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html, I need the VMs hosting K8s to have the ExtraConfig parameter `disk.enableUUID` set. I've tested.

Without this, when a disk is attached to the VM, there is no info about the disk present in `/dev/disk/by-id`, which is something we need.